### PR TITLE
Fix mandelbrot formula

### DIFF
--- a/main.js
+++ b/main.js
@@ -66,13 +66,13 @@ function draw() {
                 iteration = 0;
                 cp_x = -4 * x_offset + x / zoom; // cp = complex plane 
                 cp_y = -3 * y_offset + y / zoom; // cp = complex plane 
-                cx = 1; // c = composite- composite number
-                cy = 0; // c = composite- composite number                       
-    
-                while (iteration < maxIteration && (cx * cx + cy * cy) < 5) {
-                    cc = cx * cy; // c = composite 
+                cx = cp_x; // c = composite- composite number
+                cy = cp_y; // c = composite- composite number                       
+
+                while (iteration < maxIteration && (cx * cx + cy * cy) < 4) {
+                    cx_prev = cx;
                     cx = cx * cx - cy * cy + cp_x;
-                    cy = 3 * cc - cp_y;
+                    cy = 2 * cx_prev * cy + cp_y;
                     iteration++;
                 }
     


### PR DESCRIPTION
There was a small mistake in the z^2+c formula. This PR fixes it and produces a nice mandelbrot image.
That's the result after my changes:
![image](https://user-images.githubusercontent.com/7378222/220733427-f05b7ae5-6c01-466b-80bf-9f77d750a84c.png)
